### PR TITLE
Fix model path not found

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -67,6 +67,14 @@ def _xywh2cs(x, y, w, h, aspect_ratio):
     scale = np.array([w, h], dtype=np.float32)
     return center, scale
 
+def check_model_path(model_path):
+    # Checks to see if the model exists, if not try adding ComfyUI/ to the start to fix possible errors on Windows (maybe others too)
+    if not os.path.exists(model_path):
+        new_model_path = os.path.join("ComfyUI", model_path)
+        if os.path.exists(new_model_path):
+            return new_model_path
+    return model_path
+
 def generate(image, type, device):
   num_classes = dataset_settings[type]['num_classes']
   input_size = dataset_settings[type]['input_size']
@@ -77,6 +85,9 @@ def generate(image, type, device):
     model_path = 'models/schp/exp-schp-201908301523-atr.pth'
   elif type == 'pascal':
     model_path = 'models/schp/exp-schp-201908270938-pascal-person-part.pth'
+
+  # Check and adjust the model path if necessary
+  model_path = check_model_path(model_path)
 
   model = networks.init_model('resnet101', num_classes=num_classes, pretrained=None)
   state_dict = torch.load(model_path)['state_dict']


### PR DESCRIPTION
This project tries to load from a hardcoded models/schp folder path.
There is likely a more correct way to do this for ComfyUI, but with this small change:

- If model exists: use path
- otherwise prepend `ComfyUI` to the path (`ComfyUI/models/schp...`) and check if that exists, if it does use that.
- Otherwise error as usual

I assume this error happens on Windows because of the `run.bat` files leaving the CWD as the launch folder, and ComfyUI is inside a subfolder called `ComfyUI`.

`models` doesn't exist in the root folder on Windows (at least with portable installs)

This fixed the issues I had and the project works as expected now.

Fixes #20
